### PR TITLE
Replace parser with clojure inspired reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,23 @@
 
 Parens is a LISP-like scripting layer for `Go` (or `Golang`).
 
-See [benchmarks](#benchmarks).
+## Features
+
+* Highly Customizable reader/parser through a read table (Inspired by Clojure)
+* Built-in data types: string, number, character, keyword, symbol, list, vector
+* Multiple number formats supported: decimal, octal, hexadecimal, radix and scientific notations.
+* Full unicode support. Symbols can include unicode characters (Example: `find-δ`, `π` etc.)
+* Character Literals with support for:
+  1. simple literals  (e.g., `\a` for `a`)
+  2. special literals (e.g., `\newline`, `\tab` etc.)
+  3. unicode literals (e.g., `\u00A5` for `¥` etc.)
+* A simple `stdlib` which acts as reference for extending and provides some simple useful functions and macros.
 
 ## Installation
 
-To embed parens in your application import `github.com/spy16/parens`.
+To embed Parens in your application import `github.com/spy16/parens`.
 
-For stand-alone usage, install the parens binary using:
+For stand-alone usage, install the Parens binary using:
 
 ```bash
 go get -u -v github.com/spy16/parens/cmd/parens
@@ -23,14 +33,13 @@ Then you can
 2. Run a lisp file using `parens <filename>` command.
 3. Execute a LISP string using `parens -e "(+ 1 2)"`
 
-
 ## Usage
 
 Take a look at `cmd/parens/main.go` for a good example.
 
 Check out `examples/` for supported constructs.
 
-## Goals:
+## Goals
 
 ### 1. Simple
 
@@ -62,12 +71,11 @@ The type of `scope` argument in any `parens` function is the following interface
 ```go
 // Scope is responsible for managing bindings.
 type Scope interface {
-	Get(name string) (interface{}, error)
-	Bind(name string, v interface{}, doc ...string) error
-	Root() Scope
+    Get(name string) (interface{}, error)
+    Bind(name string, v interface{}, doc ...string) error
+    Root() Scope
 }
 ```
-
 
 ### 3. Interoperable
 
@@ -88,7 +96,6 @@ scope.Bind("sin", math.Sin)
 parens.ExecuteStr("(println banner)", scope)
 parens.ExecuteStr(`(printf "value of π is = %f" π)`, scope)
 ```
-
 
 ### 4. Extensible Semantics
 
@@ -125,35 +132,17 @@ val, _ := parens.ExecuteStr(src, scope)
 
 See `stdlib/macros.go` for some built-in macros.
 
-## Parens is *NOT*:
+## Parens is *NOT*
 
 1. An implementaion of a particular LISP dialect (like scheme, common-lisp etc.)
 2. A new dialect of LISP
 
-
-## Benchmarks
-
-| Name                                             | Runs       | Time       | Memory   | Allocations  |
-| ------------------------------------------------ | ---------- | ---------- | -------- | ------------ |
-| BenchmarkParens_Execute/Execute-8                | 1000000    | 1569 ns/op | 448 B/op | 21 allocs/op |
-| BenchmarkParens_Execute/ExecuteExpr-8            | 5000000    | 329 ns/op  | 112 B/op | 5 allocs/op  |
-| BenchmarkParens_FunctionCall/DirectCall-8        | 2000000000 | 0.29 ns/op | 0 B/op   | 0 allocs/op  |
-| BenchmarkParens_FunctionCall/CallThroughParens-8 | 2000000    | 827 ns/op  | 224 B/op | 9 allocs/op  |
-| BenchmarkNonVariadicCall/Normal-8                | 2000000000 | 0.28 ns/op | 0 B/op   | 0 allocs/op  |
-| BenchmarkNonVariadicCall/Reflection-8            | 5000000    | 370 ns/op  | 104 B/op | 4 allocs/op  |
-| BenchmarkNonVariadicCall/WithTypeConversion-8    | 5000000    | 367 ns/op  | 104 B/op | 4 allocs/op  |
-| BenchmarkVariadicCall/Normal-8                   | 500000000  | 3.22 ns/op | 0 B/op   | 0 allocs/op  |
-| BenchmarkVariadicCall/Reflection-8               | 5000000    | 366 ns/op  | 104 B/op | 4 allocs/op  |
-| BenchmarkVariadicCall/WithTypeConversion-8       | 5000000    | 347 ns/op  | 104 B/op | 4 allocs/op  |
-
-See `v0.0.6` or lower for old benchmarks.
-
 ## TODO
 
-- [ ] Better error reporting
-- [ ] Optimization
-- [ ] `Go` code generation?
-
+* [ ] Better error reporting
+* [ ] Optimization
+* [ ] `Go` code generation?
 
 ## License
+
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fspy16%2Fparens.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fspy16%2Fparens?ref=badge_large)

--- a/examples/recursion.lisp
+++ b/examples/recursion.lisp
@@ -1,8 +1,8 @@
 ; This example shows definition of a recursive function
 (defn factorial [n]
-      (cond
-        ((== n 1) n)
-        (true (* (factorial (- n 1)) n))))
+        (cond
+              ((== n 1.0) n)
+              (true (* (factorial (- n 1)) n))))
 
 
 ; finally call the factorial function

--- a/examples/simple.lisp
+++ b/examples/simple.lisp
@@ -4,7 +4,8 @@
 
 ; look under the hood
 (inspect hello)
-(println (type +))
+(println
+  (type +))
 
 ; calling variadic Go functions
 (println "Hello" "from" "Parens!")
@@ -15,7 +16,7 @@
 ; let starts a new scope
 (let
   (label π 3)
-  (printf "integer part of pi is %f\n" π))
+  (printf "integer part of pi is %d\n" π))
 
 ; value of π should now be reset to original
 (printf "but real value of pi is %f\n" π)
@@ -24,21 +25,38 @@
 ; parens supports UTF-8
 (label ∂ 0)
 (label ∑ +)
-(label ≠ (lambda [a b] (not (== a b))))
+(label ≠
+       (lambda [a b]
+         (not
+           (== a b))))
 
-(println "1 + 2 =" (∑ 1 2))
-(println "false and nil are not same =" (≠ false nil))
+(println "1 + 2 ="
+         (∑ 1 2))
+(println "false and nil are not same ="
+         (≠ false nil))
 
-(label sign (lambda [in] (cond ((> in 0) "positive") ((< in 0) "negative") (true "zero"))))
+(label sign
+       (lambda [in]
+         (cond
+           ((> in 0) "positive")
+           ((< in 0) "negative")
+           (true "zero"))))
 
 ; defining a lambda
-(label square (lambda [a] (* a a)))
+(label square
+       (lambda [a]
+         (* a a)))
 
 ; calling a lambda, obviously
-(printf "square of 2 is = %f\n" (square 2))
+(printf "square of 2 is = %f\n"
+        (square 2))
 
 ; we need to do some math obviously
-(printf "complex math answer %f\n" (* 1 (- 2 (+ 1 (/ 3 3)))))
+(printf "complex math answer %f\n"
+        (* 1
+           (- 2
+              (+ 1
+                 (/ 3 3)))))
 
 ; time for real stuff.. fibonacci!
 (defn fib [n]
@@ -47,6 +65,5 @@
         (true (+ (fib (- n 1)) (fib (- n 2))))))
 
 ; what is the 10th number in the fibonacci sequence
-(printf "10th number in the fibonacci sequence = %f\n" (fib 10))
-
-
+(printf "10th number in the fibonacci sequence = %f\n"
+        (fib 10))

--- a/examples/simple.lisp
+++ b/examples/simple.lisp
@@ -1,28 +1,28 @@
-; need help ?
+;; need help ?
 (doc println)
 (dump-scope)
 
-; look under the hood
+;; look under the hood
 (inspect hello)
 (println
   (type +))
 
-; calling variadic Go functions
+;; calling variadic Go functions
 (println "Hello" "from" "Parens!")
 
-; binding values
+;; binding values
 (label π 3.1412)
 
-; let starts a new scope
+;; let starts a new scope
 (let
   (label π 3)
   (printf "integer part of pi is %d\n" π))
 
-; value of π should now be reset to original
+;; value of π should now be reset to original
 (printf "but real value of pi is %f\n" π)
 
-; let's use some cool looking characters since
-; parens supports UTF-8
+;; let's use some cool looking characters since
+;; parens supports UTF-8
 (label ∂ 0)
 (label ∑ +)
 (label ≠
@@ -42,28 +42,46 @@
            ((< in 0) "negative")
            (true "zero"))))
 
-; defining a lambda
+;; defining a lambda
 (label square
        (lambda [a]
          (* a a)))
 
-; calling a lambda, obviously
+;; calling a lambda, obviously
 (printf "square of 2 is = %f\n"
         (square 2))
 
-; we need to do some math obviously
+;; we need to do some math obviously
 (printf "complex math answer %f\n"
         (* 1
            (- 2
               (+ 1
                  (/ 3 3)))))
 
-; time for real stuff.. fibonacci!
+;; time for real stuff.. fibonacci!
 (defn fib [n]
       (cond
         ((< n 2) n)
         (true (+ (fib (- n 1)) (fib (- n 2))))))
 
-; what is the 10th number in the fibonacci sequence
+;; what is the 10th number in the fibonacci sequence
 (printf "10th number in the fibonacci sequence = %f\n"
         (fib 10))
+
+;; parens supports character literals
+(printf "Is \\u00A5 same as '¥'? = %t\n" (== \u00A5 \¥))
+
+(println "Different Numbers: ")
+
+(println
+ 1234                                                        ; simple integer (int64)
+ 3.142                                                       ; simple double precision floating point (float64)
+ -1.23445                                                    ; negative floating point number
+ 010                                                         ; octal representation of 8
+ -010                                                        ; octal representation of -8
+ 0xF                                                         ; hexadecimal representation of 15
+ -0xAF                                                       ; negative hexadecimal number -175
+ 1e3                                                         ; scientific notation for 1x10^3 = 1000
+ 1.5e3                                                       ; scientific notation for 1.5x10^3 = 1500
+ 10e-1                                                       ; scientific notation with negative exponent
+ )

--- a/examples/spec.lisp
+++ b/examples/spec.lisp
@@ -1,0 +1,50 @@
+; All the constructs supported by the Reader (with default read
+; table.)
+
+; strings --------------------------------------------------------
+"Hello"                                                     ; simple string
+"Hello\tWorld"                                              ; string with escape sequences
+
+"this is going
+to be a multi
+line string"                                                ; a multi-line string
+
+; characters -----------------------------------------------------
+\a                                                          ; simple character literal representing 'a'
+\newline                                                    ; special character literal representing '\n'
+\u00A5                                                      ; unicode character literal representing '¥'
+
+; numbers --------------------------------------------------------
+1234                                                        ; simple integer (int64)
+3.142                                                       ; simple double precision floating point (float64)
+-1.23445                                                    ; negative floating point number
+010                                                         ; octal representation of 8
+-010                                                        ; octal representation of -8
+0xF                                                         ; hexadecimal representation of 15
+-0xAF                                                       ; negative hexadecimal number -175
+1e3                                                         ; scientific notation for 1x10^3 = 1000
+1.5e3                                                       ; scientific notation for 1.5x10^3 = 1500
+10e-1                                                       ; scientific notation with negative exponent
+
+; keywords -------------------------------------------------------
+:key                                                        ; simple ASCII keyword
+:find-Ψ                                                     ; a keyword with non non-ASCII
+
+; symbols --------------------------------------------------------
+hello                                                       ; simple ASCII symbol
+calculate-λ                                                 ; symbol with non-ASCII
+
+; quote/unquote --------------------------------------------------
+'hello                                                      ; quoted symbol
+'()                                                         ; quoted list
+~(x 1)                                                      ; unquoting
+
+; lists ----------------------------------------------------------
+()                                                          ; empty list
+(+ 1 2)                                                     ; function/macro/special form invocation
+(+, 1, 2)                                                   ; same as above, forms separated by ","
+
+; vectors --------------------------------------------------------
+[]                                                          ; empty vector
+[1 2 3 4]                                                   ; vector entries separated by space
+[1, 2, 3, 4]                                                ; vector entries can be separated by "," as well

--- a/examples/threading_macros.lisp
+++ b/examples/threading_macros.lisp
@@ -1,4 +1,5 @@
-(defn square [n] (* n n))
+(defn square [n]
+  (* n n))
 
 ; threading-first and threading-last macros can be
 ; used to reduce nesting.
@@ -7,10 +8,12 @@
 (->
   (+ 1 2)
   (square)
-  (println " is the square of the summation"))
+  (println "is the square of the summation"))
 
 ; above expression without threading-first macro:
-(println (square (+ 1 2)) " is the square of the summation")
+(println
+  (square
+    (+ 1 2)) "is the square of the summation")
 
 ; thread-last macro
 (->>
@@ -19,4 +22,6 @@
   (println "Square of the summation is "))
 
 ; above expression without threading-last macro:
-(println "Square of the summation is " (square (+ 1 2)))
+(println "Square of the summation is "
+  (square
+    (+ 1 2)))

--- a/exprs_test.go
+++ b/exprs_test.go
@@ -1,0 +1,163 @@
+package parens_test
+
+import (
+	"github.com/spy16/parens"
+	"reflect"
+	"testing"
+)
+
+func TestInt64_Eval(t *testing.T) {
+	testFormEval(t, evalTestCase{
+		form:     parens.Int64(10),
+		getScope: nil,
+		want:     int64(10),
+	})
+}
+
+func TestFloat64_Eval(t *testing.T) {
+	testFormEval(t, evalTestCase{
+		form:     parens.Float64(10),
+		getScope: nil,
+		want:     float64(10),
+	})
+}
+
+func TestKeyword_Eval(t *testing.T) {
+	testFormEval(t, evalTestCase{
+		form:     parens.Keyword(":hello"),
+		getScope: nil,
+		want:     parens.Keyword(":hello"),
+	})
+}
+
+func TestCharacter_Eval(t *testing.T) {
+	testFormEval(t, evalTestCase{
+		form:     parens.Character('A'),
+		getScope: nil,
+		want:     'A',
+	})
+}
+
+func TestString_Eval(t *testing.T) {
+	testFormEval(t, evalTestCase{
+		form:     parens.String("hello"),
+		getScope: nil,
+		want:     "hello",
+	})
+}
+
+func TestSymbol_Eval(t *testing.T) {
+	testAllFormEval(t, []evalTestCase{
+		{
+			name: "WithBinding",
+			form: parens.Symbol("hello"),
+			getScope: func() parens.Scope {
+				scope := parens.NewScope(nil)
+				_ = scope.Bind("hello", parens.Int64(10))
+				return scope
+			},
+			want: parens.Int64(10),
+		},
+		{
+			name: "WithoutBinding",
+			form: parens.Symbol("non-existent-symbol"),
+			getScope: func() parens.Scope {
+				scope := parens.NewScope(nil)
+				_ = scope.Bind("hello", parens.Int64(10))
+				return scope
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	})
+}
+
+func TestVector_Eval(t *testing.T) {
+	testAllFormEval(t, []evalTestCase{
+		{
+			name: "SimpleVector",
+			form: parens.Vector{
+				parens.Float64(1.3),
+			},
+			getScope: nil,
+			want: []interface{}{
+				float64(1.3),
+			},
+		},
+		{
+			name: "VectorWithSymbol",
+			form: parens.Vector{
+				parens.Float64(1.3),
+				parens.Symbol("pi"),
+			},
+			getScope: func() parens.Scope {
+				scope := parens.NewScope(nil)
+				_ = scope.Bind("pi", parens.Float64(3.14))
+				return scope
+			},
+			want: []interface{}{
+				float64(1.3),
+				parens.Float64(3.14),
+			},
+		},
+		{
+			name: "VectorWithUnboundSymbol",
+			form: parens.Vector{
+				parens.Symbol("pi"),
+			},
+			getScope: func() parens.Scope { return parens.NewScope(nil) },
+			want:     []interface{}(nil),
+			wantErr:  true,
+		},
+	})
+}
+
+func TestModule_Eval(t *testing.T) {
+	testAllFormEval(t, []evalTestCase{
+		{
+			name: "Literals",
+			form: parens.Module{
+				parens.String("hello"),
+				parens.Int64(10),
+				parens.Vector{},
+				parens.Keyword("hello"),
+				parens.Float64(1.3),
+			},
+			getScope: nil,
+			want:     float64(1.3),
+		},
+	})
+}
+
+func testFormEval(t *testing.T, tt evalTestCase) {
+	var scope parens.Scope
+	if tt.getScope != nil {
+		scope = tt.getScope()
+	}
+	got, err := tt.form.Eval(scope)
+	if (err != nil) != tt.wantErr {
+		t.Errorf("Eval() error = %v, wantErr %v", err, tt.wantErr)
+		return
+	}
+	if !reflect.DeepEqual(got, tt.want) {
+		t.Errorf("Eval() got = %#v, want %#v", got, tt.want)
+	}
+}
+
+func testAllFormEval(t *testing.T, tests []evalTestCase) {
+	t.Parallel()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testFormEval(t, tt)
+		})
+	}
+}
+
+type evalTestCase struct {
+	name     string
+	getScope func() parens.Scope
+	form     parens.Expr
+	want     interface{}
+	wantErr  bool
+}

--- a/gen/doc.go
+++ b/gen/doc.go
@@ -1,2 +1,0 @@
-// Package gen provides functions for Go code generation from lisp.
-package gen

--- a/parens.go
+++ b/parens.go
@@ -7,25 +7,14 @@ import (
 )
 
 // ExecuteStr is a convenience wrapper for Execute.
-func ExecuteStr(src string, env Scope, ext ...Matcher) (interface{}, error) {
+func ExecuteStr(src string, env Scope) (interface{}, error) {
 	return Execute(strings.NewReader(src), env)
 }
 
 // Execute reads until EOF or an error from the RuneScanner and executes the
 // read s-expressions in the given scope.
-func Execute(rd io.RuneScanner, env Scope, ext ...Matcher) (interface{}, error) {
-	expr, err := Parse(rd, ext...)
-	if err != nil {
-		return nil, err
-	}
-
-	return ExecuteExpr(expr, env)
-}
-
-// ExecuteOne reads runes enough to construct one s-exp and executes the s-exp
-// with given scope.
-func ExecuteOne(rd io.RuneScanner, env Scope, ext ...Matcher) (interface{}, error) {
-	expr, err := ParseOne(rd, ext...)
+func Execute(rd io.Reader, env Scope) (interface{}, error) {
+	expr, err := Parse(rd)
 	if err != nil {
 		return nil, err
 	}

--- a/parens_test.go
+++ b/parens_test.go
@@ -20,15 +20,11 @@ func BenchmarkParens_Execute(suite *testing.B) {
 		}
 	})
 
-	expr := ListExpr(
+	expr := List(
 		[]Expr{
-			SymbolExpr("add"),
-			NumberExpr{
-				NumStr: "1",
-			},
-			NumberExpr{
-				NumStr: "2",
-			},
+			Symbol("add"),
+			Int64(1),
+			Int64(2),
 		})
 
 	suite.Run("ExecuteExpr", func(b *testing.B) {
@@ -63,16 +59,16 @@ func BenchmarkParens_FunctionCall(suite *testing.B) {
 func TestExecute_Success(t *testing.T) {
 	scope := NewScope(nil)
 
-	res, err := ExecuteOne(strings.NewReader("10"), scope)
+	res, err := Execute(strings.NewReader("10"), scope)
 	assert.NoError(t, err)
 	require.NotNil(t, res)
-	assert.Equal(t, 10.0, res)
+	assert.Equal(t, int64(10), res)
 }
 
 func TestExecute_EvalFailure(t *testing.T) {
 	scope := NewScope(nil)
 
-	res, err := ExecuteOne(strings.NewReader("(hello)"), scope)
+	res, err := Execute(strings.NewReader("(hello)"), scope)
 	require.Error(t, err)
 	assert.Nil(t, res)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,291 +1,660 @@
-package parens
+package parens_test
 
 import (
-	"bufio"
-	"errors"
+	"bytes"
+	"github.com/spy16/parens"
 	"io"
+	"os"
+	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestParse(suite *testing.T) {
-	suite.Parallel()
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        io.Reader
+		fileName string
+	}{
+		{
+			name:     "WithStringReader",
+			r:        strings.NewReader(":test"),
+			fileName: "<string>",
+		},
+		{
+			name:     "WithBytesReader",
+			r:        bytes.NewReader([]byte(":test")),
+			fileName: "<bytes>",
+		},
+		{
+			name:     "WihFile",
+			r:        os.NewFile(0, "test.lisp"),
+			fileName: "test.lisp",
+		},
+	}
 
-	suite.Run("ReaderFailure", func(t *testing.T) {
-		expr, err := ParseOne(bufio.NewReader(readerFunc(func([]byte) (int, error) {
-			return 0, errors.New("failed")
-		})))
-		require.Error(t, err)
-		assert.Nil(t, expr)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rd := parens.New(tt.r)
+			if rd == nil {
+				t.Errorf("New() should return instance of Reader, got nil")
+			} else if rd.File != tt.fileName {
+				t.Errorf("parens.File = \"%s\", want = \"%s\"", rd.File, tt.name)
+			}
+		})
+	}
+}
+
+func TestReader_SetMacro(t *testing.T) {
+	t.Run("UnsetDefaultMacro", func(t *testing.T) {
+		rd := parens.New(strings.NewReader("~hello"))
+		rd.SetMacro('~', nil) // remove unquote operator
+
+		var want parens.Expr
+		want = parens.Symbol("~hello")
+
+		got, err := rd.One()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got = %v, want = %v", got, want)
+		}
 	})
 
-	suite.Run("UnexpectedEOF", func(t *testing.T) {
-		expr, err := ParseOne(reader(")"))
-		require.Error(t, err)
-		assert.Nil(t, expr)
+	t.Run("CustomMacro", func(t *testing.T) {
+		rd := parens.New(strings.NewReader("~hello"))
+		rd.SetMacro('~', func(rd *parens.Reader, _ rune) (parens.Expr, error) {
+			var ru []rune
+			for {
+				r, err := rd.NextRune()
+				if err != nil {
+					if err == io.EOF {
+						break
+					}
+					return nil, err
+				}
+
+				if rd.IsTerminal(r) {
+					break
+				}
+				ru = append(ru, r)
+			}
+
+			return parens.String(ru), nil
+		}) // override unquote operator
+
+		var want parens.Expr
+		want = parens.String("hello")
+
+		got, err := rd.One()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got = %v, want = %v", got, want)
+		}
 	})
 }
 
-func TestParse_Vector(suite *testing.T) {
-	suite.Parallel()
+func TestReader_All(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		want    parens.Module
+		wantErr bool
+	}{
+		{
+			name: "ValidLiteralSample",
+			src:  `"Hello\tWorld" 123 12.34 -0xF   +010    0b1010     \a :hello 'hello`,
+			want: parens.Module{
+				parens.String("Hello\tWorld"),
+				parens.Int64(123),
+				parens.Float64(12.34),
+				parens.Int64(-15),
+				parens.Int64(8),
+				parens.Int64(10),
+				parens.Character('a'),
+				parens.Keyword(":hello"),
+				parens.List{
+					parens.Symbol("quote"),
+					parens.Symbol("hello"),
+				},
+			},
+		},
+		{
+			name: "WithComment",
+			src:  `:valid-keyword ; comment should return errSkip`,
+			want: parens.Module{parens.Keyword(":valid-keyword")},
+		},
+		{
+			name:    "UnterminatedString",
+			src:     `:valid-keyword "unterminated string literal`,
+			wantErr: true,
+		},
+		{
+			name: "CommentFollowedByForm",
+			src:  `; comment should return errSkip` + "\n" + `:valid-keyword`,
+			want: parens.Module{parens.Keyword(":valid-keyword")},
+		},
+		{
+			name:    "UnterminatedList",
+			src:     `:valid-keyword (add 1 2`,
+			wantErr: true,
+		},
+		{
+			name:    "UnterminatedVector",
+			src:     `:valid-keyword [1 2`,
+			wantErr: true,
+		},
+		{
+			name:    "EOFAfterQuote",
+			src:     `:valid-keyword '`,
+			wantErr: true,
+		},
+		{
+			name:    "CommentAfterQuote",
+			src:     `:valid-keyword ';hello world`,
+			wantErr: true,
+		},
+		{
+			name:    "UnbalancedParenthesis",
+			src:     `())`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parens.New(strings.NewReader(tt.src)).All()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("All() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("All() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
-	suite.Run("UnexpectedEOF", func(t *testing.T) {
-		expr, err := ParseOne(reader("]"))
-		require.Error(t, err)
-		assert.Equal(t, io.EOF, err)
-		assert.Nil(t, expr)
-	})
-
-	suite.Run("UnexpectedEOF", func(t *testing.T) {
-		expr, err := ParseOne(reader("["))
-		require.Error(t, err)
-		assert.Equal(t, io.EOF, err)
-		assert.Nil(t, expr)
-	})
-
-	suite.Run("EmptyList", func(t *testing.T) {
-		expr, err := ParseOne(reader("[]"))
-		require.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, VectorExpr{}, expr)
-		assert.Equal(t, 0, len(expr.(VectorExpr)))
-	})
-
-	suite.Run("SimpleList", func(t *testing.T) {
-		expr, err := ParseOne(reader("[1 \"hello\"]"))
-		require.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, VectorExpr{}, expr)
-		assert.Equal(t, 2, len(expr.(VectorExpr)))
-	})
-
-	suite.Run("NestedList", func(t *testing.T) {
-		expr, err := ParseOne(reader("[1 [[] 'hello]]"))
-		require.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, VectorExpr{}, expr)
-		assert.Equal(t, 2, len(expr.(VectorExpr)))
+func TestReader_One(t *testing.T) {
+	executeAllReaderTests(t, []readerTestCase{
+		{
+			name:    "Empty",
+			src:     "",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "QuotedEOF",
+			src:     "';comment is a no-op form\n",
+			wantErr: true,
+		},
+		{
+			name:    "ListEOF",
+			src:     "( 1",
+			wantErr: true,
+		},
+		{
+			name: "UnQuote",
+			src:  "~(x 3)",
+			want: parens.List{
+				parens.Symbol("unquote"),
+				parens.List{
+					parens.Symbol("x"),
+					parens.Int64(3),
+				},
+			},
+		},
 	})
 }
 
-func TestParse_Symbol(suite *testing.T) {
-	suite.Parallel()
-
-	suite.Run("AlphaSymbol", func(t *testing.T) {
-		expr, err := ParseOne(reader("hello"))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, SymbolExpr(""), expr)
-		assert.Equal(t, "hello", string(expr.(SymbolExpr)))
-	})
-
-	suite.Run("AlphaNumericSymbol", func(t *testing.T) {
-		expr, err := ParseOne(reader("hello123"))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, SymbolExpr(""), expr)
-		assert.Equal(t, "hello123", string(expr.(SymbolExpr)))
-	})
-
-	suite.Run("NonASCIISymbol", func(t *testing.T) {
-		expr, err := ParseOne(reader("π"))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, SymbolExpr(""), expr)
-		assert.Equal(t, "π", string(expr.(SymbolExpr)))
-	})
-
-	suite.Run("NumerciSymbol", func(t *testing.T) {
-		expr, err := ParseOne(reader("1.2.3"))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, SymbolExpr(""), expr)
-		assert.Equal(t, "1.2.3", string(expr.(SymbolExpr)))
-	})
-}
-
-func TestParse_String(suite *testing.T) {
-	suite.Parallel()
-
-	suite.Run("SimpleString", func(t *testing.T) {
-		expr, err := ParseOne(reader(`"hello"`))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, StringExpr(""), expr)
-		assert.Equal(t, "hello", string(expr.(StringExpr)))
-	})
-
-	suite.Run("EscapeQuote", func(t *testing.T) {
-		expr, err := ParseOne(reader(`"hello\"world"`))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, StringExpr(""), expr)
-		assert.Equal(t, "hello\"world", string(expr.(StringExpr)))
-	})
-
-	suite.Run("EscapeNewline", func(t *testing.T) {
-		expr, err := ParseOne(reader(`"hello\nworld"`))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, StringExpr(""), expr)
-		assert.Equal(t, "hello\nworld", string(expr.(StringExpr)))
-	})
-
-	suite.Run("EscapeTab", func(t *testing.T) {
-		expr, err := ParseOne(reader(`"hello\tworld"`))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, StringExpr(""), expr)
-		assert.Equal(t, "hello\tworld", string(expr.(StringExpr)))
-	})
-
-	suite.Run("EscapeCR", func(t *testing.T) {
-		expr, err := ParseOne(reader(`"hello\rworld"`))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, StringExpr(""), expr)
-		assert.Equal(t, "hello\rworld", string(expr.(StringExpr)))
-	})
-
-	suite.Run("PrematureEOF", func(t *testing.T) {
-		expr, err := ParseOne(reader(`"hello`))
-		require.Error(t, err)
-		assert.Equal(t, io.EOF, err)
-		assert.Nil(t, expr)
-	})
-
-}
-
-func TestParse_Number(suite *testing.T) {
-	suite.Parallel()
-
-	suite.Run("NumberFollowedBySymbol", func(t *testing.T) {
-		expr, err := ParseOne(reader(`-12.34 hello`))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, NumberExpr{}, expr)
-		assert.Equal(t, "-12.34", expr.(NumberExpr).NumStr)
-	})
-
-	suite.Run("SimpleInteger", func(t *testing.T) {
-		expr, err := ParseOne(reader(`12`))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, NumberExpr{}, expr)
-		assert.Equal(t, "12", expr.(NumberExpr).NumStr)
-	})
-
-	suite.Run("Signed(-)Integer", func(t *testing.T) {
-		expr, err := ParseOne(reader(`-12`))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, NumberExpr{}, expr)
-		assert.Equal(t, "-12", expr.(NumberExpr).NumStr)
-	})
-
-	suite.Run("Signed(+)Integer", func(t *testing.T) {
-		expr, err := ParseOne(reader(`+12`))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, NumberExpr{}, expr)
-		assert.Equal(t, "+12", expr.(NumberExpr).NumStr)
-	})
-
-	suite.Run("SimpleFloat", func(t *testing.T) {
-		expr, err := ParseOne(reader(`+12.34`))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, NumberExpr{}, expr)
-		assert.Equal(t, "+12.34", expr.(NumberExpr).NumStr)
-	})
-
-	suite.Run("SignedFloat", func(t *testing.T) {
-		expr, err := ParseOne(reader(`-12.34`))
-		assert.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, NumberExpr{}, expr)
-		assert.Equal(t, "-12.34", expr.(NumberExpr).NumStr)
-	})
-}
-
-func TestParse_Keyword(suite *testing.T) {
-	suite.Parallel()
-
-	suite.Run("SimpleKeyword", func(t *testing.T) {
-		expr, err := ParseOne(reader(`:hello world`))
-		require.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, KeywordExpr(""), expr)
-		assert.Equal(t, "hello", string(expr.(KeywordExpr)))
-	})
-
-	suite.Run("ComplexKeyword", func(t *testing.T) {
-		expr, err := ParseOne(reader(`:hello/world`))
-		require.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, KeywordExpr(""), expr)
-		assert.Equal(t, "hello/world", string(expr.(KeywordExpr)))
-	})
-
-	suite.Run("SkipsEscape", func(t *testing.T) {
-		expr, err := ParseOne(reader(`:hello\nworld`))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unexpected character")
-		assert.Nil(t, expr)
+func TestReader_One_Number(t *testing.T) {
+	executeAllReaderTests(t, []readerTestCase{
+		{
+			name: "NumberWithLeadingSpaces",
+			src:  "    +1234",
+			want: parens.Int64(1234),
+		},
+		{
+			name: "PositiveInt",
+			src:  "+1245",
+			want: parens.Int64(1245),
+		},
+		{
+			name: "NegativeInt",
+			src:  "-234",
+			want: parens.Int64(-234),
+		},
+		{
+			name: "PositiveFloat",
+			src:  "+1.334",
+			want: parens.Float64(1.334),
+		},
+		{
+			name: "NegativeFloat",
+			src:  "-1.334",
+			want: parens.Float64(-1.334),
+		},
+		{
+			name: "PositiveHex",
+			src:  "0x124",
+			want: parens.Int64(0x124),
+		},
+		{
+			name: "NegativeHex",
+			src:  "-0x124",
+			want: parens.Int64(-0x124),
+		},
+		{
+			name: "PositiveOctal",
+			src:  "0123",
+			want: parens.Int64(0123),
+		},
+		{
+			name: "NegativeOctal",
+			src:  "-0123",
+			want: parens.Int64(-0123),
+		},
+		{
+			name: "PositiveBinary",
+			src:  "0b10",
+			want: parens.Int64(2),
+		},
+		{
+			name: "NegativeBinary",
+			src:  "-0b10",
+			want: parens.Int64(-2),
+		},
+		{
+			name: "PositiveBase2Radix",
+			src:  "2r10",
+			want: parens.Int64(2),
+		},
+		{
+			name: "NegativeBase2Radix",
+			src:  "-2r10",
+			want: parens.Int64(-2),
+		},
+		{
+			name: "PositiveBase4Radix",
+			src:  "4r123",
+			want: parens.Int64(27),
+		},
+		{
+			name: "NegativeBase4Radix",
+			src:  "-4r123",
+			want: parens.Int64(-27),
+		},
+		{
+			name: "ScientificSimple",
+			src:  "1e10",
+			want: parens.Float64(1e10),
+		},
+		{
+			name: "ScientificNegativeExponent",
+			src:  "1e-10",
+			want: parens.Float64(1e-10),
+		},
+		{
+			name: "ScientificWithDecimal",
+			src:  "1.5e10",
+			want: parens.Float64(1.5e+10),
+		},
+		{
+			name:    "FloatStartingWith0",
+			src:     "012.3",
+			want:    parens.Float64(012.3),
+			wantErr: false,
+		},
+		{
+			name:    "InvalidValue",
+			src:     "1ABe13",
+			wantErr: true,
+		},
+		{
+			name:    "InvalidScientificFormat",
+			src:     "1e13e10",
+			wantErr: true,
+		},
+		{
+			name:    "InvalidExponent",
+			src:     "1e1.3",
+			wantErr: true,
+		},
+		{
+			name:    "InvalidRadixFormat",
+			src:     "1r2r3",
+			wantErr: true,
+		},
+		{
+			name:    "RadixBase3WithDigit4",
+			src:     "-3r1234",
+			wantErr: true,
+		},
+		{
+			name:    "RadixMissingValue",
+			src:     "2r",
+			wantErr: true,
+		},
+		{
+			name:    "RadixInvalidBase",
+			src:     "2ar",
+			wantErr: true,
+		},
+		{
+			name:    "RadixWithFloat",
+			src:     "2.3r4",
+			wantErr: true,
+		},
+		{
+			name:    "DecimalPointInBinary",
+			src:     "0b1.0101",
+			wantErr: true,
+		},
+		{
+			name:    "InvalidDigitForOctal",
+			src:     "08",
+			wantErr: true,
+		},
+		{
+			name:    "IllegalNumberFormat",
+			src:     "9.3.2",
+			wantErr: true,
+		},
 	})
 }
 
-func TestParse_List(suite *testing.T) {
-	suite.Parallel()
-
-	suite.Run("UnexpectedEOF", func(t *testing.T) {
-		expr, err := ParseOne(reader(")"))
-		require.Error(t, err)
-		assert.Equal(t, io.EOF, err)
-		assert.Nil(t, expr)
-	})
-
-	suite.Run("UnexpectedEOF", func(t *testing.T) {
-		expr, err := ParseOne(reader("("))
-		require.Error(t, err)
-		assert.Equal(t, io.EOF, err)
-		assert.Nil(t, expr)
-	})
-
-	suite.Run("EmptyList", func(t *testing.T) {
-		expr, err := ParseOne(reader("()"))
-		require.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, ListExpr{}, expr)
-		assert.Equal(t, 0, len(expr.(ListExpr)))
-	})
-
-	suite.Run("SimpleList", func(t *testing.T) {
-		expr, err := ParseOne(reader("(1 \"hello\")"))
-		require.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, ListExpr{}, expr)
-		assert.Equal(t, 2, len(expr.(ListExpr)))
-	})
-
-	suite.Run("NestedList", func(t *testing.T) {
-		expr, err := ParseOne(reader("(1 ([] 'hello))"))
-		require.NoError(t, err)
-		require.NotNil(t, expr)
-		require.IsType(t, ListExpr{}, expr)
-		assert.Equal(t, 2, len(expr.(ListExpr)))
+func TestReader_One_Keyword(t *testing.T) {
+	executeAllReaderTests(t, []readerTestCase{
+		{
+			name: "SimpleASCII",
+			src:  `:test`,
+			want: parens.Keyword(":test"),
+		},
+		{
+			name: "LeadingTrailingSpaces",
+			src:  "          :test          ",
+			want: parens.Keyword(":test"),
+		},
+		{
+			name: "SimpleUnicode",
+			src:  `:∂`,
+			want: parens.Keyword(":∂"),
+		},
+		{
+			name: "WithSpecialChars",
+			src:  `:this-is-valid?`,
+			want: parens.Keyword(":this-is-valid?"),
+		},
+		{
+			name: "FollowedByMacroChar",
+			src:  `:this-is-valid'hello`,
+			want: parens.Keyword(":this-is-valid"),
+		},
 	})
 }
 
-type readerFunc func([]byte) (int, error)
-
-func (rf readerFunc) Read(data []byte) (int, error) {
-	return rf(data)
+func TestReader_One_Character(t *testing.T) {
+	executeAllReaderTests(t, []readerTestCase{
+		{
+			name: "ASCIILetter",
+			src:  `\a`,
+			want: parens.Character('a'),
+		},
+		{
+			name: "ASCIIDigit",
+			src:  `\1`,
+			want: parens.Character('1'),
+		},
+		{
+			name: "Unicode",
+			src:  `\∂`,
+			want: parens.Character('∂'),
+		},
+		{
+			name: "Newline",
+			src:  `\newline`,
+			want: parens.Character('\n'),
+		},
+		{
+			name: "FormFeed",
+			src:  `\formfeed`,
+			want: parens.Character('\f'),
+		},
+		{
+			name: "Unicode",
+			src:  `\u00AE`,
+			want: parens.Character('®'),
+		},
+		{
+			name:    "InvalidUnicode",
+			src:     `\uHELLO`,
+			wantErr: true,
+		},
+		{
+			name:    "OutOfRangeUnicode",
+			src:     `\u-100`,
+			wantErr: true,
+		},
+		{
+			name:    "UnknownSpecial",
+			src:     `\hello`,
+			wantErr: true,
+		},
+		{
+			name:    "EOF",
+			src:     `\`,
+			wantErr: true,
+		},
+	})
 }
 
-func reader(s string) io.RuneScanner {
-	return strings.NewReader(s)
+func TestReader_One_String(t *testing.T) {
+	executeAllReaderTests(t, []readerTestCase{
+		{
+			name: "SimpleString",
+			src:  `"hello"`,
+			want: parens.String("hello"),
+		},
+		{
+			name: "EscapeQuote",
+			src:  `"double quote is \""`,
+			want: parens.String(`double quote is "`),
+		},
+		{
+			name: "EscapeSlash",
+			src:  `"hello\\world"`,
+			want: parens.String(`hello\world`),
+		},
+		{
+			name:    "UnexpectedEOF",
+			src:     `"double quote is`,
+			wantErr: true,
+		},
+		{
+			name:    "InvalidEscape",
+			src:     `"hello \x world"`,
+			wantErr: true,
+		},
+		{
+			name:    "EscapeEOF",
+			src:     `"hello\`,
+			wantErr: true,
+		},
+	})
+}
+
+func TestReader_One_Symbol(t *testing.T) {
+	executeAllReaderTests(t, []readerTestCase{
+		{
+			name: "SimpleASCII",
+			src:  `hello`,
+			want: parens.Symbol("hello"),
+		},
+		{
+			name: "Unicode",
+			src:  `find-∂`,
+			want: parens.Symbol("find-∂"),
+		},
+		{
+			name: "SingleChar",
+			src:  `+`,
+			want: parens.Symbol("+"),
+		},
+	})
+}
+
+func TestReader_One_List(t *testing.T) {
+	executeAllReaderTests(t, []readerTestCase{
+		{
+			name: "EmptyList",
+			src:  `()`,
+			want: parens.List(nil),
+		},
+		{
+			name: "ListWithOneEntry",
+			src:  `(help)`,
+			want: parens.List{
+				parens.Symbol("help"),
+			},
+		},
+		{
+			name: "ListWithMultipleEntry",
+			src:  `(+ 0xF 3.1413)`,
+			want: parens.List{
+				parens.Symbol("+"),
+				parens.Int64(15),
+				parens.Float64(3.1413),
+			},
+		},
+		{
+			name: "ListWithCommaSeparator",
+			src:  `(+,0xF,3.1413)`,
+			want: parens.List{
+				parens.Symbol("+"),
+				parens.Int64(15),
+				parens.Float64(3.1413),
+			},
+		},
+		{
+			name: "MultiLine",
+			src: `(+
+                      0xF
+                      3.1413
+					)`,
+			want: parens.List{
+				parens.Symbol("+"),
+				parens.Int64(15),
+				parens.Float64(3.1413),
+			},
+		},
+		{
+			name: "MultiLineWithComments",
+			src: `(+         ; plus operator adds numerical values
+                      0xF    ; hex representation of 15
+                      3.1413 ; value of math constant pi
+                  )`,
+			want: parens.List{
+				parens.Symbol("+"),
+				parens.Int64(15),
+				parens.Float64(3.1413),
+			},
+		},
+		{
+			name:    "UnexpectedEOF",
+			src:     "(+ 1 2 ",
+			wantErr: true,
+		},
+	})
+}
+
+func TestReader_One_Vector(t *testing.T) {
+	executeAllReaderTests(t, []readerTestCase{
+		{
+			name: "Empty",
+			src:  `[]`,
+			want: parens.Vector(nil),
+		},
+		{
+			name: "WithOneEntry",
+			src:  `[help]`,
+			want: parens.Vector([]parens.Expr{
+				parens.Symbol("help"),
+			}),
+		},
+		{
+			name: "WithMultipleEntry",
+			src:  `[+ 0xF 3.1413]`,
+			want: parens.Vector([]parens.Expr{
+				parens.Symbol("+"),
+				parens.Int64(15),
+				parens.Float64(3.1413),
+			}),
+		},
+		{
+			name: "WithCommaSeparator",
+			src:  `[+,0xF,3.1413]`,
+			want: parens.Vector([]parens.Expr{
+				parens.Symbol("+"),
+				parens.Int64(15),
+				parens.Float64(3.1413),
+			}),
+		},
+		{
+			name: "MultiLine",
+			src: `[+
+                      0xF
+                      3.1413
+					]`,
+			want: parens.Vector([]parens.Expr{
+				parens.Symbol("+"),
+				parens.Int64(15),
+				parens.Float64(3.1413),
+			}),
+		},
+		{
+			name: "MultiLineWithComments",
+			src: `[+         ; plus operator adds numerical values
+                      0xF    ; hex representation of 15
+                      3.1413 ; value of math constant pi
+                  ]`,
+			want: parens.Vector([]parens.Expr{
+				parens.Symbol("+"),
+				parens.Int64(15),
+				parens.Float64(3.1413),
+			}),
+		},
+		{
+			name:    "UnexpectedEOF",
+			src:     "[+ 1 2 ",
+			wantErr: true,
+		},
+	})
+}
+
+type readerTestCase struct {
+	name    string
+	src     string
+	want    parens.Expr
+	wantErr bool
+}
+
+func executeAllReaderTests(t *testing.T, tests []readerTestCase) {
+	t.Parallel()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parens.New(strings.NewReader(tt.src)).One()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("One() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("One() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/stream.go
+++ b/stream.go
@@ -1,0 +1,97 @@
+package parens
+
+import (
+	"io"
+	"strings"
+	"unicode"
+)
+
+// Stream provides functions to read from a rune reader and also maintains
+// the stream information such as filename and position in stream.
+type Stream struct {
+	File string
+
+	rs        io.RuneReader
+	buf       []rune
+	line, col int
+	lastCol   int
+}
+
+// NextRune returns next rune from the stream and advances the stream.
+func (stream *Stream) NextRune() (rune, error) {
+	var r rune
+	if len(stream.buf) > 0 {
+		r = stream.buf[0]
+		stream.buf = stream.buf[1:]
+	} else {
+		temp, _, err := stream.rs.ReadRune()
+		if err != nil {
+			return -1, err
+		}
+
+		r = temp
+	}
+
+	if r == '\n' {
+		stream.line++
+		stream.lastCol = stream.col
+		stream.col = 0
+	} else {
+		stream.col++
+	}
+
+	return r, nil
+}
+
+// Unread can be used to return runes consumed from the stream back to the
+// stream. Un-reading more runes than read is guaranteed to work but might
+// cause inconsistency in stream positional information.
+func (stream *Stream) Unread(runes ...rune) {
+	newLine := false
+	for _, r := range runes {
+		if r == '\n' {
+			newLine = true
+			break
+		}
+	}
+
+	if newLine {
+		stream.line--
+		stream.col = stream.lastCol
+	} else {
+		stream.col--
+	}
+
+	stream.buf = append(runes, stream.buf...)
+}
+
+// Info returns information about the stream including file name and the
+// position of the reader.
+func (stream Stream) Info() (file string, line, col int) {
+	file = strings.TrimSpace(stream.File)
+	return file, stream.line + 1, stream.col
+}
+
+// SkipSpaces consumes and discards runes from stream repeatedly until a
+// character that is not a whitespace is identified. Along with standard
+// unicode  white-space characters "," is also considered  a white-space
+// and discarded.
+func (stream *Stream) SkipSpaces() error {
+	for {
+		r, err := stream.NextRune()
+		if err != nil {
+			return err
+		}
+
+		if !isSpace(r) {
+			stream.Unread(r)
+			break
+		}
+	}
+
+	return nil
+}
+
+func isSpace(r rune) bool {
+	return unicode.IsSpace(r) || r == ','
+}


### PR DESCRIPTION
I will merge the branch to master soon and bump the version. 

* Removed `ParseOne` and `ExecuteOne` (`Reader.One` and `ExecuteExpr` can be used to same effect)
* Renamed all `Expr` implementations to not have `Expr` suffix (e.g., `NumberExpr` --> `Number`)

Apart from these, everything else should remain same,.