### PR TITLE
Fix multiple papercuts

### DIFF
--- a/exprs.go
+++ b/exprs.go
@@ -38,7 +38,7 @@ func (i64 Int64) String() string { return fmt.Sprintf("%d", i64) }
 type String string
 
 // Eval returns the unquoted string value.
-func (se String) Eval(scope Scope) (interface{}, error) { return string(se), nil }
+func (se String) Eval(scope Scope) (interface{}, error) { return String(se), nil }
 
 func (se String) String() string { return fmt.Sprintf("\"%s\"", string(se)) }
 

--- a/exprs.go
+++ b/exprs.go
@@ -16,7 +16,7 @@ type Float64 float64
 
 // Eval returns the underlying double-precision float value.
 func (f64 Float64) Eval(scope Scope) (interface{}, error) {
-	return float64(f64), nil
+	return f64, nil
 }
 
 func (f64 Float64) String() string { return fmt.Sprintf("%f", f64) }
@@ -27,7 +27,7 @@ type Int64 int64
 
 // Eval returns the underlying integer value.
 func (i64 Int64) Eval(scope Scope) (interface{}, error) {
-	return int64(i64), nil
+	return i64, nil
 }
 
 func (i64 Int64) String() string { return fmt.Sprintf("%d", i64) }
@@ -38,7 +38,7 @@ func (i64 Int64) String() string { return fmt.Sprintf("%d", i64) }
 type String string
 
 // Eval returns the unquoted string value.
-func (se String) Eval(scope Scope) (interface{}, error) { return String(se), nil }
+func (se String) Eval(scope Scope) (interface{}, error) { return se, nil }
 
 func (se String) String() string { return fmt.Sprintf("\"%s\"", string(se)) }
 
@@ -48,7 +48,7 @@ func (se String) String() string { return fmt.Sprintf("\"%s\"", string(se)) }
 type Character rune
 
 // Eval returns the character value.
-func (char Character) Eval(scope Scope) (interface{}, error) { return rune(char), nil }
+func (char Character) Eval(scope Scope) (interface{}, error) { return char, nil }
 
 func (char Character) String() string { return fmt.Sprintf("\\%c", rune(char)) }
 
@@ -58,7 +58,7 @@ type Keyword string
 // Eval returns the keyword value.
 func (kw Keyword) Eval(scope Scope) (interface{}, error) { return kw, nil }
 
-func (kw Keyword) String() string { return string(kw) }
+func (kw Keyword) String() string { return fmt.Sprintf(":%s", string(kw)) }
 
 // Symbol represents a name given to a value in memory.
 type Symbol string

--- a/exprs_test.go
+++ b/exprs_test.go
@@ -1,16 +1,17 @@
 package parens_test
 
 import (
-	"github.com/spy16/parens"
 	"reflect"
 	"testing"
+
+	"github.com/spy16/parens"
 )
 
 func TestInt64_Eval(t *testing.T) {
 	testFormEval(t, evalTestCase{
 		form:     parens.Int64(10),
 		getScope: nil,
-		want:     int64(10),
+		want:     parens.Int64(10),
 	})
 }
 
@@ -18,7 +19,7 @@ func TestFloat64_Eval(t *testing.T) {
 	testFormEval(t, evalTestCase{
 		form:     parens.Float64(10),
 		getScope: nil,
-		want:     float64(10),
+		want:     parens.Float64(10),
 	})
 }
 
@@ -34,7 +35,7 @@ func TestCharacter_Eval(t *testing.T) {
 	testFormEval(t, evalTestCase{
 		form:     parens.Character('A'),
 		getScope: nil,
-		want:     'A',
+		want:     parens.Character('A'),
 	})
 }
 
@@ -42,7 +43,7 @@ func TestString_Eval(t *testing.T) {
 	testFormEval(t, evalTestCase{
 		form:     parens.String("hello"),
 		getScope: nil,
-		want:     "hello",
+		want:     parens.String("hello"),
 	})
 }
 
@@ -81,7 +82,7 @@ func TestVector_Eval(t *testing.T) {
 			},
 			getScope: nil,
 			want: []interface{}{
-				float64(1.3),
+				parens.Float64(1.3),
 			},
 		},
 		{
@@ -96,7 +97,7 @@ func TestVector_Eval(t *testing.T) {
 				return scope
 			},
 			want: []interface{}{
-				float64(1.3),
+				parens.Float64(1.3),
 				parens.Float64(3.14),
 			},
 		},
@@ -124,7 +125,7 @@ func TestModule_Eval(t *testing.T) {
 				parens.Float64(1.3),
 			},
 			getScope: nil,
-			want:     float64(1.3),
+			want:     parens.Float64(1.3),
 		},
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/k0kubun/pp v2.3.0+incompatible
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/sys v0.0.0-20181031143558-9b800f95dbbc // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRU
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=

--- a/parens_test.go
+++ b/parens_test.go
@@ -62,7 +62,7 @@ func TestExecute_Success(t *testing.T) {
 	res, err := Execute(strings.NewReader("10"), scope)
 	assert.NoError(t, err)
 	require.NotNil(t, res)
-	assert.Equal(t, int64(10), res)
+	assert.Equal(t, Int64(10), res)
 }
 
 func TestExecute_EvalFailure(t *testing.T) {

--- a/parser.go
+++ b/parser.go
@@ -564,6 +564,11 @@ type ReaderError struct {
 	Column int
 }
 
+// Unwrap returns the error's cause
+func (err ReaderError) Unwrap() error {
+	return err.Cause
+}
+
 func (err ReaderError) Error() string {
 	if e, ok := err.Cause.(ReaderError); ok {
 		return e.Error()

--- a/parser.go
+++ b/parser.go
@@ -235,7 +235,7 @@ func readNumber(rd *Reader, init rune) (Expr, error) {
 	case decimalPoint:
 		v, err := strconv.ParseFloat(numStr, 64)
 		if err != nil {
-			return nil, errors.Wrap(err, "illegal number format")
+			return nil, errors.Wrapf(err, "illegal number format %s", numStr)
 			// return nil, fmt.Errorf("illegal number format: '%s'", numStr)
 		}
 		return Float64(v), nil
@@ -246,7 +246,7 @@ func readNumber(rd *Reader, init rune) (Expr, error) {
 	default:
 		v, err := strconv.ParseInt(numStr, 0, 64)
 		if err != nil {
-			return nil, errors.Wrap(err, "illegal number format")
+			return nil, errors.Wrapf(err, "illegal number format %s", numStr)
 			// return nil, fmt.Errorf("illegal number format '%s'", numStr)
 		}
 

--- a/parser.go
+++ b/parser.go
@@ -260,8 +260,13 @@ func readSymbol(rd *Reader, init rune) (Expr, error) {
 	return Symbol(s), nil
 }
 
-func readKeyword(rd *Reader, init rune) (Expr, error) {
-	token, err := readToken(rd, init)
+func readKeyword(rd *Reader, _ rune) (Expr, error) {
+	r, err := rd.NextRune()
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := readToken(rd, r)
 	if err != nil {
 		return nil, err
 	}

--- a/parser.go
+++ b/parser.go
@@ -3,7 +3,6 @@ package parens
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -13,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/pkg/errors"
 )
 
 var (
@@ -234,7 +235,8 @@ func readNumber(rd *Reader, init rune) (Expr, error) {
 	case decimalPoint:
 		v, err := strconv.ParseFloat(numStr, 64)
 		if err != nil {
-			return nil, fmt.Errorf("illegal number format: '%s'", numStr)
+			return nil, errors.Wrap(err, "illegal number format")
+			// return nil, fmt.Errorf("illegal number format: '%s'", numStr)
 		}
 		return Float64(v), nil
 
@@ -244,7 +246,8 @@ func readNumber(rd *Reader, init rune) (Expr, error) {
 	default:
 		v, err := strconv.ParseInt(numStr, 0, 64)
 		if err != nil {
-			return nil, fmt.Errorf("illegal number format '%s'", numStr)
+			return nil, errors.Wrap(err, "illegal number format")
+			// return nil, fmt.Errorf("illegal number format '%s'", numStr)
 		}
 
 		return Int64(v), nil

--- a/parser.go
+++ b/parser.go
@@ -264,12 +264,7 @@ func readSymbol(rd *Reader, init rune) (Expr, error) {
 }
 
 func readKeyword(rd *Reader, _ rune) (Expr, error) {
-	r, err := rd.NextRune()
-	if err != nil {
-		return nil, err
-	}
-
-	token, err := readToken(rd, r)
+	token, err := readToken(rd, -1)
 	if err != nil {
 		return nil, err
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,12 +2,13 @@ package parens_test
 
 import (
 	"bytes"
-	"github.com/spy16/parens"
 	"io"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/spy16/parens"
 )
 
 func TestNew(t *testing.T) {
@@ -117,7 +118,7 @@ func TestReader_All(t *testing.T) {
 				parens.Int64(8),
 				parens.Int64(10),
 				parens.Character('a'),
-				parens.Keyword(":hello"),
+				parens.Keyword("hello"),
 				parens.List{
 					parens.Symbol("quote"),
 					parens.Symbol("hello"),
@@ -127,7 +128,7 @@ func TestReader_All(t *testing.T) {
 		{
 			name: "WithComment",
 			src:  `:valid-keyword ; comment should return errSkip`,
-			want: parens.Module{parens.Keyword(":valid-keyword")},
+			want: parens.Module{parens.Keyword("valid-keyword")},
 		},
 		{
 			name:    "UnterminatedString",
@@ -137,7 +138,7 @@ func TestReader_All(t *testing.T) {
 		{
 			name: "CommentFollowedByForm",
 			src:  `; comment should return errSkip` + "\n" + `:valid-keyword`,
-			want: parens.Module{parens.Keyword(":valid-keyword")},
+			want: parens.Module{parens.Keyword("valid-keyword")},
 		},
 		{
 			name:    "UnterminatedList",
@@ -372,27 +373,27 @@ func TestReader_One_Keyword(t *testing.T) {
 		{
 			name: "SimpleASCII",
 			src:  `:test`,
-			want: parens.Keyword(":test"),
+			want: parens.Keyword("test"),
 		},
 		{
 			name: "LeadingTrailingSpaces",
 			src:  "          :test          ",
-			want: parens.Keyword(":test"),
+			want: parens.Keyword("test"),
 		},
 		{
 			name: "SimpleUnicode",
 			src:  `:∂`,
-			want: parens.Keyword(":∂"),
+			want: parens.Keyword("∂"),
 		},
 		{
 			name: "WithSpecialChars",
 			src:  `:this-is-valid?`,
-			want: parens.Keyword(":this-is-valid?"),
+			want: parens.Keyword("this-is-valid?"),
 		},
 		{
 			name: "FollowedByMacroChar",
 			src:  `:this-is-valid'hello`,
-			want: parens.Keyword(":this-is-valid"),
+			want: parens.Keyword("this-is-valid"),
 		},
 	})
 }


### PR DESCRIPTION
Hi @spy16,

I've been developing a small language using my own fork of Parens.  In doing so, I've made the following changes, which I think should be merged upstream.

If any of these changes seem absurd, please let me know.

# Changes

### 1.  Add `ReaderError.Unwrap` method

`ReaderError` contains a `Cause` field.  Since Go 1.13, the `errors` package contains [`errors.Unwrap`](https://godoc.org/errors#Unwrap), which can retrieve the cause of any error matching the following interface:

```go
type unwrapper interface {
    Unwrap() error
}
```

This feature is also supported by [`github.com/pkg/errors`](https://godoc.org/github.com/pkg/errors), which in turn is **officially recommended by the Go team** ([Exhibit A](https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully), [Exhibit B](https://dave.cheney.net/2016/06/12/stack-traces-and-the-errors-package)).

### 2.  Wrap `strconv.ParseFloat` and `strconv.ParseInt` errors with extra debug info

Parens currently fails to parse e.g. integers above 9223372036854775807 due to overflow.  Currently, this returns an extremely unhelpful `illegal number format` error.  This has been augmented by the `github.com/pkg/errors` package mentioned above.

```go
case decimalPoint:
	v, err := strconv.ParseFloat(numStr, 64)
	if err != nil {
		// return nil, fmt.Errorf("illegal number format: '%s'", numStr)
		return nil, errors.Wrap(err, "illegal number format")
	}
	return Float64(v), nil
```

```go
default:
	v, err := strconv.ParseInt(numStr, 0, 64)
	if err != nil {
		// return nil, fmt.Errorf("illegal number format '%s'", numStr)
		return nil, errors.Wrapf(err, "illegal number format %s", numStr)
	}

	return Int64(v), nil
```

This provides a **major advantage** when debugging for two reasons:

1. The default error message is more informative
1. We can print a detailed stack trace via `fmt.Printf("%+v", errors.Unwrap(err))`.

### 3. Make numbers, strings, keyword and chars evaluate to themselves

Currently, typing `[ "foo" "bar" ]` at the REPL will print `[foo bar]`.  The output should instead be identical to the input.  Since you seemed to be emulating Clojure in https://github.com/spy16/parens/issues/4, used  https://clojure.org/reference/evaluation as a reference for correcting this.

It states:

>Strings, numbers, characters, true, false, nil and keywords evaluate to themselves.

Note that it may be worth implementing a `Bool` type, but I have not done so.

### 4. Remove the leading `:` from the data representation of a keyword

The leading `:` in a keyword should not be part of the data, consistent with how characters and quoted forms are handled.

I made the appropriate modifications, ensuring that keywords are still properly printed and parsed.
