### PR TITLE
Remove Env.parent

### DIFF
--- a/concurmap.go
+++ b/concurmap.go
@@ -8,8 +8,7 @@ import (
 
 var _ ConcurrentMap = (*mutexMap)(nil)
 
-// ConcurrentMap implementation can be set on the root context to customise
-// the map used for storing variables in the stack frames.
+// ConcurrentMap is used by the Env to store variables in the stack frames.
 type ConcurrentMap interface {
 	// Store should store the key-value pair in the map.
 	Store(key string, val value.Any)


### PR DESCRIPTION
This PR replaces `Env.parent` with a pure stack-copying approach to `Env.fork()`.
[Previous discussion](https://github.com/spy16/parens/pull/20#discussion_r488007526).

N.B.:  this is to be merged in `feature/interpreter`, not `master`.

Naturally, I'm happy to discuss any use-cases for `Env.parent` that I may have overlooked! 

(P.S.:  if you're happy with this, feel free to merge.)