### PR TITLE
Return error from Equals() method.

### DIFF
--- a/parens.go
+++ b/parens.go
@@ -15,6 +15,11 @@ var (
 
 	// ErrNotInvokable is returned by InvokeExpr when the target is not invokable.
 	ErrNotInvokable = errors.New("not invokable")
+
+	// ErrIncomparableTypes is returned by Any.Comp when a comparison between two tpyes
+	// is undefined.  Users should generally consider the types to be not equal in such
+	// cases, but not assume any ordering.
+	ErrIncomparableTypes = errors.New("incomparable types")
 )
 
 // New returns a new root context initialised based on given options.

--- a/values.go
+++ b/values.go
@@ -72,9 +72,9 @@ type Int64 int64
 func (i64 Int64) SExpr() (string, error) { return i64.String(), nil }
 
 // Equals returns true if the other Value is also an integer and has same Value.
-func (i64 Int64) Equals(other Any) bool {
+func (i64 Int64) Equals(other Any) (bool, error) {
 	val, isInt := other.(Int64)
-	return isInt && (val == i64)
+	return isInt && (val == i64), nil
 }
 
 func (i64 Int64) String() string { return strconv.Itoa(int(i64)) }
@@ -86,9 +86,9 @@ type Float64 float64
 func (f64 Float64) SExpr() (string, error) { return f64.String(), nil }
 
 // Equals returns true if 'other' is also a float and has same Value.
-func (f64 Float64) Equals(other Any) bool {
+func (f64 Float64) Equals(other Any) (bool, error) {
 	val, isFloat := other.(Float64)
-	return isFloat && (val == f64)
+	return isFloat && (val == f64), nil
 }
 
 func (f64 Float64) String() string {
@@ -105,9 +105,9 @@ type Bool bool
 func (b Bool) SExpr() (string, error) { return b.String(), nil }
 
 // Equals returns true if 'other' is a boolean and has same logical Value.
-func (b Bool) Equals(other Any) bool {
+func (b Bool) Equals(other Any) (bool, error) {
 	val, ok := other.(Bool)
-	return ok && (val == b)
+	return ok && (val == b), nil
 }
 
 func (b Bool) String() string {
@@ -126,9 +126,9 @@ func (char Char) SExpr() (string, error) {
 }
 
 // Equals returns true if the other Value is also a character and has same Value.
-func (char Char) Equals(other Any) bool {
+func (char Char) Equals(other Any) (bool, error) {
 	val, isChar := other.(Char)
-	return isChar && (val == char)
+	return isChar && (val == char), nil
 }
 
 func (char Char) String() string { return fmt.Sprintf("\\%c", char) }
@@ -140,9 +140,9 @@ type String string
 func (str String) SExpr() (string, error) { return str.String(), nil }
 
 // Equals returns true if 'other' is string and has same Value.
-func (str String) Equals(other Any) bool {
+func (str String) Equals(other Any) (bool, error) {
 	otherStr, isStr := other.(String)
-	return isStr && (otherStr == str)
+	return isStr && (otherStr == str), nil
 }
 
 func (str String) String() string { return fmt.Sprintf("\"%s\"", string(str)) }
@@ -154,9 +154,9 @@ type Symbol string
 func (sym Symbol) SExpr() (string, error) { return string(sym), nil }
 
 // Equals returns true if the other Value is also a symbol and has same Value.
-func (sym Symbol) Equals(other Any) bool {
+func (sym Symbol) Equals(other Any) (bool, error) {
 	otherSym, isSym := other.(Symbol)
-	return isSym && (sym == otherSym)
+	return isSym && (sym == otherSym), nil
 }
 
 func (sym Symbol) String() string { return string(sym) }
@@ -168,9 +168,9 @@ type Keyword string
 func (kw Keyword) SExpr() (string, error) { return kw.String(), nil }
 
 // Equals returns true if the other Value is keyword and has same Value.
-func (kw Keyword) Equals(other Any) bool {
+func (kw Keyword) Equals(other Any) (bool, error) {
 	otherKW, isKeyword := other.(Keyword)
-	return isKeyword && (otherKW == kw)
+	return isKeyword && (otherKW == kw), nil
 }
 
 func (kw Keyword) String() string { return fmt.Sprintf(":%s", string(kw)) }

--- a/values_test.go
+++ b/values_test.go
@@ -1,0 +1,183 @@
+package parens_test
+
+import (
+	"testing"
+
+	"github.com/spy16/parens"
+)
+
+func TestComp(t *testing.T) {
+	for _, tt := range []struct {
+		desc    string
+		a, b    parens.Any
+		op      func(a, b parens.Any) (bool, error)
+		want    bool
+		wantErr bool
+	}{
+		// Nil
+		{
+			desc: "nil == nil",
+			a:    parens.Nil{},
+			b:    parens.Nil{},
+			op:   parens.Eq,
+			want: true,
+		},
+		{
+			desc: "nil == false",
+			a:    parens.Nil{},
+			b:    parens.Bool(false),
+			op:   parens.Eq,
+		},
+
+		// Bool
+		{
+			desc: "true == true",
+			a:    parens.Bool(true),
+			b:    parens.Bool(true),
+			op:   parens.Eq,
+			want: true,
+		},
+		{
+			desc: "false == false",
+			a:    parens.Bool(true),
+			b:    parens.Bool(true),
+			op:   parens.Eq,
+			want: true,
+		},
+		{
+			desc: "false == true",
+			a:    parens.Bool(false),
+			b:    parens.Bool(true),
+			op:   parens.Eq,
+		},
+
+		// Int64
+		{
+			desc: "0 == 0",
+			a:    parens.Int64(0),
+			b:    parens.Int64(0),
+			op:   parens.Eq,
+			want: true,
+		},
+		{
+			desc: "0 < 1",
+			a:    parens.Int64(0),
+			b:    parens.Int64(1),
+			op:   parens.Lt,
+			want: true,
+		},
+		{
+			desc: "1 > 0",
+			a:    parens.Int64(1),
+			b:    parens.Int64(0),
+			op:   parens.Gt,
+			want: true,
+		},
+		{
+			desc: "0 <= 1",
+			a:    parens.Int64(0),
+			b:    parens.Int64(1),
+			op:   parens.Le,
+			want: true,
+		},
+		{
+			desc: "1 >= 0",
+			a:    parens.Int64(1),
+			b:    parens.Int64(0),
+			op:   parens.Ge,
+			want: true,
+		},
+		{
+			desc: "0 <= 0",
+			a:    parens.Int64(0),
+			b:    parens.Int64(0),
+			op:   parens.Le,
+			want: true,
+		},
+		{
+			desc: "0 >= 0",
+			a:    parens.Int64(0),
+			b:    parens.Int64(0),
+			op:   parens.Ge,
+			want: true,
+		},
+
+		// Float64
+		{
+			desc: "0. == 0.",
+			a:    parens.Float64(0),
+			b:    parens.Float64(0),
+			op:   parens.Eq,
+			want: true,
+		},
+		{
+			desc: "0. < 1.",
+			a:    parens.Float64(0),
+			b:    parens.Float64(1),
+			op:   parens.Lt,
+			want: true,
+		},
+		{
+			desc: "1. > 0.",
+			a:    parens.Float64(1),
+			b:    parens.Float64(0),
+			op:   parens.Gt,
+			want: true,
+		},
+		{
+			desc: "0. <= 1.",
+			a:    parens.Float64(0),
+			b:    parens.Float64(1),
+			op:   parens.Le,
+			want: true,
+		},
+		{
+			desc: "1. >= 0.",
+			a:    parens.Float64(1),
+			b:    parens.Float64(0),
+			op:   parens.Ge,
+			want: true,
+		},
+		{
+			desc: "0. <= 0.",
+			a:    parens.Float64(0),
+			b:    parens.Float64(0),
+			op:   parens.Le,
+			want: true,
+		},
+		{
+			desc: "0. >= 0.",
+			a:    parens.Float64(0),
+			b:    parens.Float64(0),
+			op:   parens.Ge,
+			want: true,
+		},
+		{
+			// LinkedList
+			desc: "(1 2 3) == (1 2 3)",
+			a:    parens.NewList(parens.Int64(1), parens.Int64(2), parens.Int64(3)),
+			b:    parens.NewList(parens.Int64(1), parens.Int64(2), parens.Int64(3)),
+			op:   parens.Eq,
+			want: true,
+		},
+		{
+			// LinkedList
+			desc: "(1 2 3) == (1 2 nil)",
+			a:    parens.NewList(parens.Int64(1), parens.Int64(2), parens.Int64(3)),
+			b:    parens.NewList(parens.Int64(1), parens.Int64(2), parens.Nil{}),
+			op:   parens.Eq,
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := tt.op(tt.a, tt.b)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("%s error = %#v, wantErr %#v", tt.desc, err, tt.wantErr)
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("%s returned %t, expected %t", tt.desc, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
@spy16 I've encountered the need to return an errors from the `Equals()` method in all of my Wetware datatypes.  Again, the reason is that attribute lookups on Cap'n Proto structs can fail.