### PR TITLE
Fix hard-coded dependence on parens.Symbol

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -29,7 +29,7 @@ func (ba BuiltinAnalyzer) Analyze(env *Env, form Any) (Expr, error) {
 
 	switch f := form.(type) {
 	case Symbol:
-		v := env.resolve(string(f))
+		v := env.Resolve(string(f))
 		if v == nil {
 			return nil, Error{
 				Cause:   ErrNotFound,

--- a/env.go
+++ b/env.go
@@ -77,9 +77,9 @@ func (env *Env) expandAnalyze(form Any) (Expr, error) {
 	return env.analyzer.Analyze(env, form)
 }
 
-// fork creates a child context from Env and returns it. The child context
+// Fork creates a child context from Env and returns it. The child context
 // can be used as context for an independent thread of execution.
-func (env *Env) fork() *Env {
+func (env *Env) Fork() *Env {
 	return &Env{
 		ctx:      env.ctx,
 		globals:  env.globals,

--- a/env.go
+++ b/env.go
@@ -46,6 +46,20 @@ func (env *Env) Eval(form Any) (Any, error) {
 	return expr.Eval(env)
 }
 
+// Resolve a symbol.
+func (env Env) Resolve(sym string) Any {
+	if len(env.stack) > 0 {
+		// check inside top of the stack for local bindings.
+		top := env.stack[len(env.stack)-1]
+		if v, found := top.Vars[sym]; found {
+			return v
+		}
+	}
+	// return the value from global bindings if found.
+	v, _ := env.globals.Load(sym)
+	return v
+}
+
 func (env *Env) expandAnalyze(form Any) (Expr, error) {
 	if expr, ok := form.(Expr); ok {
 		// Already an Expr, nothing to do.
@@ -89,19 +103,6 @@ func (env *Env) pop() (frame *stackFrame) {
 
 func (env *Env) setGlobal(key string, value Any) {
 	env.globals.Store(key, value)
-}
-
-func (env Env) resolve(sym string) Any {
-	if len(env.stack) > 0 {
-		// check inside top of the stack for local bindings.
-		top := env.stack[len(env.stack)-1]
-		if v, found := top.Vars[sym]; found {
-			return v
-		}
-	}
-	// return the value from global bindings if found.
-	v, _ := env.globals.Load(sym)
-	return v
 }
 
 type stackFrame struct {

--- a/expr.go
+++ b/expr.go
@@ -140,7 +140,7 @@ type GoExpr struct {
 // Eval forks the given context to get a child context and launches goroutine
 // with the child context to evaluate the
 func (ge GoExpr) Eval(env *Env) (Any, error) {
-	child := env.fork()
+	child := env.Fork()
 	go func() {
 		_, _ = child.Eval(ge.Value)
 	}()

--- a/reader/macros.go
+++ b/reader/macros.go
@@ -84,6 +84,23 @@ func UnmatchedDelimiter() Macro {
 	}
 }
 
+func symbolReader(symTable map[string]parens.Any) Macro {
+	return func(rd *Reader, init rune) (parens.Any, error) {
+		beginPos := rd.Position()
+
+		s, err := rd.Token(init)
+		if err != nil {
+			return nil, rd.annotateErr(err, beginPos, s)
+		}
+
+		if predefVal, found := symTable[s]; found {
+			return predefVal, nil
+		}
+
+		return parens.Symbol(s), nil
+	}
+}
+
 func readNumber(rd *Reader, init rune) (parens.Any, error) {
 	beginPos := rd.Position()
 
@@ -129,21 +146,6 @@ func readNumber(rd *Reader, init rune) (parens.Any, error) {
 
 		return parens.Int64(v), nil
 	}
-}
-
-func readSymbol(rd *Reader, init rune) (parens.Any, error) {
-	beginPos := rd.Position()
-
-	s, err := rd.Token(init)
-	if err != nil {
-		return nil, rd.annotateErr(err, beginPos, s)
-	}
-
-	if predefVal, found := rd.predef[s]; found {
-		return predefVal, nil
-	}
-
-	return parens.Symbol(s), nil
 }
 
 func readString(rd *Reader, init rune) (parens.Any, error) {

--- a/reader/macros.go
+++ b/reader/macros.go
@@ -131,15 +131,19 @@ func readNumber(rd *Reader, init rune) (parens.Any, error) {
 	}
 }
 
-func readRawSymbol(rd *Reader, init rune) (string, error) {
+func readSymbol(rd *Reader, init rune) (parens.Any, error) {
 	beginPos := rd.Position()
 
 	s, err := rd.Token(init)
 	if err != nil {
-		return "", rd.annotateErr(err, beginPos, s)
+		return nil, rd.annotateErr(err, beginPos, s)
 	}
 
-	return s, nil
+	if predefVal, found := rd.predef[s]; found {
+		return predefVal, nil
+	}
+
+	return parens.Symbol(s), nil
 }
 
 func readString(rd *Reader, init rune) (parens.Any, error) {

--- a/reader/macros.go
+++ b/reader/macros.go
@@ -131,7 +131,7 @@ func readNumber(rd *Reader, init rune) (parens.Any, error) {
 	}
 }
 
-func readSymbol(rd *Reader, init rune) (parens.Symbol, error) {
+func readRawSymbol(rd *Reader, init rune) (string, error) {
 	beginPos := rd.Position()
 
 	s, err := rd.Token(init)
@@ -139,7 +139,7 @@ func readSymbol(rd *Reader, init rune) (parens.Symbol, error) {
 		return "", rd.annotateErr(err, beginPos, s)
 	}
 
-	return parens.Symbol(s), nil
+	return s, nil
 }
 
 func readString(rd *Reader, init rune) (parens.Any, error) {

--- a/reader/options.go
+++ b/reader/options.go
@@ -4,6 +4,12 @@ import (
 	"github.com/spy16/parens"
 )
 
+var defaultSymTable = map[string]parens.Any{
+	"nil":   parens.Nil{},
+	"true":  parens.Bool(true),
+	"false": parens.Bool(false),
+}
+
 // Option values can be used with New() to configure the reader during init.
 type Option func(*Reader)
 
@@ -22,34 +28,25 @@ func WithNumReader(m Macro) Option {
 // Builds a parens.Symbol if nil.
 func WithSymbolReader(m Macro) Option {
 	if m == nil {
-		m = readSymbol
+		return WithBuiltinSymbolReader(defaultSymTable)
 	}
 	return func(rd *Reader) {
 		rd.symReader = m
 	}
 }
 
-// WithPredefinedSymbols maps a set of symbols to a set of values globally.
-// Reader directly returns the value in the map instead of returning the
-// symbol itself.
-func WithPredefinedSymbols(ss map[string]parens.Any) Option {
-	if ss == nil {
-		ss = map[string]parens.Any{
-			"nil":   parens.Nil{},
-			"true":  parens.Bool(true),
-			"false": parens.Bool(false),
-		}
-	}
-
-	return func(r *Reader) {
-		r.predef = ss
+// WithBuiltinSymbolReader configures the default symbol reader with given
+// symbol table.
+func WithBuiltinSymbolReader(symTable map[string]parens.Any) Option {
+	m := symbolReader(symTable)
+	return func(rd *Reader) {
+		rd.symReader = m
 	}
 }
 
 func withDefaults(opt []Option) []Option {
 	return append([]Option{
 		WithNumReader(nil),
-		WithSymbolReader(nil),
-		WithPredefinedSymbols(nil),
+		WithBuiltinSymbolReader(defaultSymTable),
 	}, opt...)
 }

--- a/reader/options.go
+++ b/reader/options.go
@@ -18,6 +18,19 @@ func WithNumReader(m Macro) Option {
 	}
 }
 
+// WithSymbolFactory sets the symbol factory function for the Reader.
+// This function will be used to transform a native Go string into a symbol
+// type that satisfies parens.Any.  Builds a parens.Symbol if nil.
+func WithSymbolFactory(f func(string) (parens.Any, error)) Option {
+	if f == nil {
+		f = func(s string) (parens.Any, error) { return parens.Symbol(s), nil }
+	}
+
+	return func(rd *Reader) {
+		rd.newSymbol = f
+	}
+}
+
 // WithPredefinedSymbols maps a set of symbols to a set of values globally.
 // Reader directly returns the value in the map instead of returning the
 // symbol itself.
@@ -38,6 +51,7 @@ func WithPredefinedSymbols(ss map[string]parens.Any) Option {
 func withDefaults(opt []Option) []Option {
 	return append([]Option{
 		WithNumReader(nil),
+		WithSymbolFactory(nil),
 		WithPredefinedSymbols(nil),
 	}, opt...)
 }

--- a/reader/options.go
+++ b/reader/options.go
@@ -18,16 +18,14 @@ func WithNumReader(m Macro) Option {
 	}
 }
 
-// WithSymbolFactory sets the symbol factory function for the Reader.
-// This function will be used to transform a native Go string into a symbol
-// type that satisfies parens.Any.  Builds a parens.Symbol if nil.
-func WithSymbolFactory(f func(string) (parens.Any, error)) Option {
-	if f == nil {
-		f = func(s string) (parens.Any, error) { return parens.Symbol(s), nil }
+// WithSymbolReader sets the symbol reader macro to be used by the Reader.
+// Builds a parens.Symbol if nil.
+func WithSymbolReader(m Macro) Option {
+	if m == nil {
+		m = readSymbol
 	}
-
 	return func(rd *Reader) {
-		rd.newSymbol = f
+		rd.symReader = m
 	}
 }
 
@@ -51,7 +49,7 @@ func WithPredefinedSymbols(ss map[string]parens.Any) Option {
 func withDefaults(opt []Option) []Option {
 	return append([]Option{
 		WithNumReader(nil),
-		WithSymbolFactory(nil),
+		WithSymbolReader(nil),
 		WithPredefinedSymbols(nil),
 	}, opt...)
 }

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -64,8 +64,7 @@ func New(r io.Reader, opts ...Option) *Reader {
 			'~':  quoteFormReader("unquote"),
 			'`':  quoteFormReader("syntax-quote"),
 		},
-		dispatch:  map[rune]Macro{},
-		numReader: readNumber,
+		dispatch: map[rune]Macro{},
 	}
 
 	for _, option := range withDefaults(opts) {
@@ -85,10 +84,9 @@ type Reader struct {
 	buf                  []rune
 	line, col            int
 	lastCol              int
-	macros               map[rune]Macro
-	dispatch             map[rune]Macro
 	dispatching          bool
-	predef               map[string]parens.Any
+	dispatch             map[rune]Macro
+	macros               map[rune]Macro
 	numReader, symReader Macro
 }
 
@@ -310,12 +308,6 @@ func (rd Reader) Container(end rune, formType string, f func(parens.Any) error) 
 	}
 
 	return nil
-}
-
-// Resolve a predefined symbol.
-func (rd *Reader) Resolve(s string) (v parens.Any, found bool) {
-	v, found = rd.predef[s]
-	return
 }
 
 // readOne is same as One() but always returns un-annotated errors.

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -90,6 +90,7 @@ type Reader struct {
 	dispatching bool
 	predef      map[string]parens.Any
 	numReader   Macro
+	newSymbol   func(string) (parens.Any, error)
 }
 
 // All consumes characters from stream until EOF and returns a list of all the forms
@@ -351,16 +352,16 @@ func (rd *Reader) readOne() (parens.Any, error) {
 		}
 	}
 
-	v, err := readSymbol(rd, r)
+	rsym, err := readRawSymbol(rd, r)
 	if err != nil {
 		return nil, err
 	}
 
-	if predefVal, found := rd.predef[string(v)]; found {
+	if predefVal, found := rd.predef[rsym]; found {
 		return predefVal, nil
 	}
 
-	return v, nil
+	return rd.newSymbol(rsym)
 }
 
 func (rd *Reader) execDispatch() (parens.Any, error) {


### PR DESCRIPTION
The `parens` codebase currently has hard-coded dependencies on `parens.Symbol`.  This makes it impossible to use a custom symbol implementation.

This PR removes such hard-coded dependencies in two places:

1. in the `Reader` (by introducing `Reader.newSymbol` and `reader.WithSymbolFactory`)
2. in `Analyzer` (by exporting `Env.Resolve` -- see note below)

Concerning point 2, the `BasicAnalyzer` calls `Env.resolve()`, using a `parens.Symbol`.  Rewriting a new `Analyzer` implementation that uses a custom symbol type requires access to the environment's `resolve` method, hence the export.

⏱️ Estimated review time:  < 5 min
✅ Merge when ready