### PR TITLE
Make SExpr() method optional on Any type.

### DIFF
--- a/parens.go
+++ b/parens.go
@@ -31,12 +31,11 @@ func New(opts ...Option) *Env {
 	return env
 }
 
-// Any represents any
-type Any interface {
-	// SExpr MUST return a parsable s-expression that can be consumed by
-	// a reader.Reader.
-	//
-	// For a human-readable implementation, implement `repl.Renderable`.
+// Any represents any form
+type Any interface{}
+
+// SExpressable forms can be rendered as s-expressions.
+type SExpressable interface {
 	SExpr() (string, error)
 }
 

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package parens
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 )
@@ -47,12 +48,17 @@ func SeqString(seq Seq, begin, end, sep string) (string, error) {
 	var b strings.Builder
 	b.WriteString(begin)
 	err := ForEach(seq, func(item Any) (bool, error) {
-		sexpr, err := item.SExpr()
-		if err != nil {
-			return false, err
+		if sxpr, ok := item.(SExpressable); ok {
+			s, err := sxpr.SExpr()
+			if err != nil {
+				return false, err
+			}
+			b.WriteString(s)
+
+		} else {
+			b.WriteString(fmt.Sprintf("%#v", item))
 		}
 
-		b.WriteString(sexpr)
 		b.WriteString(sep)
 		return false, nil
 	})


### PR DESCRIPTION
@spy16 I had initially assumed that any parens form would be renderable into a valid s-expression, but this turns out to have been a mistake.  _Most_ things can be rendered back into an s-expression, but not all.

For example, Wetware has a notion of a process (think:  UNIX process).  What does the s-expression look like for a running process?

This PR removes the `SExpr()` method from `Any`, opting instead for the optional interface `SExpressable`.  This changes is backwards-compatible.

⏱️ Estimated review time:  <5 min
✅ Merge when ready